### PR TITLE
added support for \ : i.e for windows

### DIFF
--- a/build.js
+++ b/build.js
@@ -18,9 +18,9 @@ module.exports = function build(appRoot, cb) {
         }
 
         var locales = paths.map(function (p) {
-            var m = /(.*)\/(.*)/.exec(path.relative(localeRoot, p));
+            var m = /(.*)+(\/|\\)+(.*)/.exec(path.relative(localeRoot, p));
 
-            return m[2] + '-' + m[1];
+            return m[3] + '-' + m[1];
         });
 
         async.each(locales, streamLocale, cb);


### PR DESCRIPTION
I'm using a windows base machine and it seems as though the slashes are on the other side. 
I was getting an error in the command line because the regex didn't work on line 21 in the build.js file
