### PR TITLE
Support using makara-browserify on windows platforms

### DIFF
--- a/build.js
+++ b/build.js
@@ -18,7 +18,7 @@ module.exports = function build(appRoot, cb) {
         }
 
         var locales = paths.map(function (p) {
-            var m = /(.*)\/(.*)/.exec(path.relative(localeRoot, p));
+            var m = new RegExp('(.*)\\' + path.sep + '(.*)').exec(path.relative(localeRoot, p));
 
             return m[2] + '-' + m[1];
         });

--- a/test/fixture/locales/XC/en/nested/index.properties
+++ b/test/fixture/locales/XC/en/nested/index.properties
@@ -1,0 +1,1 @@
+hello=World

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ test('build', function(t) {
 
             t.ok(result['en-XC'], "found our language in the output");
             t.equal(result['en-XC']['index.properties'].hello, 'World', "found translation");
+            t.equal(result['en-XC']['nested/index.properties'].hello, 'World', "found nested translation");
         });
 
     });


### PR DESCRIPTION
> I'm using a windows base machine and it seems as though the slashes are on the other side. 
> I was getting an error in the command line because the regex didn't work on line 21 in the build.js file
> @malikov - https://github.com/krakenjs/makara-browserify/pull/2

This PR adds support for Windows platforms. Currently, the Kraken boilerplate is not working for Windows (`grunt build` is broken).

It's WIP, because the dependency spundle https://github.com/krakenjs/spundle/pull/2 must be updated first.
