### PR TITLE
Refactor.makara builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.idea
 *.swp
 
 test/fixture/.build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ### unreleased
 
+* FIX: provide Windows path support: https://github.com/krakenjs/makara-browserify/pull/5
 * FIX: upgrade glob module to ^7 to address vulnerability in minimatch. https://github.com/jpillora/node-glob-all/issues/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### unreleased
+### v1.2.4
 
 * FIX: provide Windows path support: https://github.com/krakenjs/makara-browserify/pull/5
 * FIX: upgrade glob module to ^7 to address vulnerability in minimatch. https://github.com/jpillora/node-glob-all/issues/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v1.2.4
+### v1.2.5
 
 * FIX: provide Windows path support: https://github.com/krakenjs/makara-browserify/pull/5
 * FIX: upgrade glob module to ^7 to address vulnerability in minimatch. https://github.com/jpillora/node-glob-all/issues/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### unreleased
+
+* modify to match the `makara-builder` 2.0 API. See: https://github.com/krakenjs/makara-builder/blob/v2.x/README.md#api and https://github.com/krakenjs/makara-builder/blob/v2.x/CHANGELOG.md#v200
+
 ### v1.2.5
 
 * FIX: provide Windows path support: https://github.com/krakenjs/makara-browserify/pull/5

--- a/build.js
+++ b/build.js
@@ -1,53 +1,28 @@
-"use strict";
+'use strict';
+
 var fs = require('fs');
 var browserify = require('browserify');
-var spundle = require('spundle');
 var through = require('through2');
 var path = require('path');
-var glob = require('glob');
-var async = require('async');
-var mkdirp = require('mkdirp');
-var iferr = require('iferr');
 
-module.exports = function build(appRoot, cb) {
-    var localeRoot = path.resolve(appRoot, 'locales');
-
-    glob(path.resolve(localeRoot, '*/*/'), function (err, paths) {
-        if (err) {
-            return cb(err);
-        }
-
-        var locales = paths.map(function (p) {
-            var m = new RegExp('(.*)\\' + path.sep + '(.*)').exec(path.relative(localeRoot, p));
-
-            return m[2] + '-' + m[1];
-        });
-
-        async.each(locales, streamLocale, cb);
-    });
-
-    function streamLocale(locale, cb) {
-        var b = browserify();
-        var output = through();
-        var m = /(.*)-(.*)/.exec(locale); // Use a real BCP47 parser.
-        var outputRoot = path.resolve(appRoot, path.join('.build', locale));
-        mkdirp(outputRoot, iferr(cb, function (out) {
-            spundle(path.resolve(appRoot, 'locales'), m[2], m[1], iferr(cb, function (out) {
-                b.require(streamOf('module.exports=' + JSON.stringify(out)), { expose: '_languagepack' })
-                    .bundle()
-                    .pipe(fs.createWriteStream(path.resolve(outputRoot, '_languagepack.js')))
-                    .on('finish', cb)
-                    .on('error', cb);
-            }));
-        }));
-    }
-
-};
-
-function streamOf(str) {
+var streamOf = function (str) {
     var o = through();
     process.nextTick(function () {
         o.end(str);
     });
     return o;
-}
+};
+var writer = function (outputRoot, cb) {
+    return function (out) {
+        var b = browserify();
+        b.require(streamOf('module.exports=' + JSON.stringify(out)), { expose: '_languagepack' })
+          .bundle()
+          .pipe(fs.createWriteStream(path.resolve(outputRoot, '_languagepack.js')))
+          .on('finish', cb)
+          .on('error', cb);
+    };
+};
+
+module.exports = function build(appRoot, cb) {
+    require('makara-builder')(appRoot, writer, cb);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makara-browserify",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Tools to browserify content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makara-browserify",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Tools to browserify content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makara-browserify",
-  "version": "1.2.6-alpha.1",
+  "version": "1.2.5",
   "description": "Tools to browserify content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "browserify": "^6.2.0",
-    "makara-builder": "2.0.0-alpha.1",
+    "makara-builder": "^2.0.0",
     "makara-languagepackpath": "^1.0.0",
     "through2": "^0.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,26 +1,18 @@
 {
   "name": "makara-browserify",
-  "version": "1.2.5",
+  "version": "1.2.6-alpha.1",
   "description": "Tools to browserify content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",
   "license": "Apache 2.0",
   "repository": "https://github.com/krakenjs/makara-browserify.git",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.com/"
-  },
   "scripts": {
     "test": "tape test/**.js"
   },
   "dependencies": {
-    "async": "^0.9.0",
     "browserify": "^6.2.0",
-    "glob": "^7.0.5",
-    "iferr": "^0.1.2",
     "makara-builder": "2.0.0-alpha.1",
     "makara-languagepackpath": "^1.0.0",
-    "mkdirp": "^0.5.0",
-    "spundle": "^1.0.0",
     "through2": "^0.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "browserify": "^6.2.0",
     "glob": "^7.0.5",
     "iferr": "^0.1.2",
+    "makara-builder": "2.0.0-alpha.1",
     "makara-languagepackpath": "^1.0.0",
     "mkdirp": "^0.5.0",
     "spundle": "^1.0.0",


### PR DESCRIPTION
use makara-builder interface introduced here: https://github.com/krakenjs/makara-builder/pull/4

This pulls up the spundle and directory creation from the "writer" method and into makara-builder. Removes repeated code from this module and any other "makara-*" modules.
